### PR TITLE
Make SVIn2 hard and soft resetable (flag enabled feature)

### DIFF
--- a/okvis_ros/CMakeLists.txt
+++ b/okvis_ros/CMakeLists.txt
@@ -20,6 +20,10 @@ find_package(catkin REQUIRED
 
   imagenex831l
   #aquacore #for aqua Depth topic
+
+  ## Added by Hunter
+  std_srvs
+  nav_msgs
 )
 
 # generate dynamic reconfigure stuff
@@ -30,10 +34,15 @@ add_message_files(
   FILES
   SvinHealth.msg
 )
+add_service_files(
+  FILES
+  OdometryTrigger.srv
+)
 generate_messages(
   DEPENDENCIES
   std_msgs
   geometry_msgs
+  nav_msgs
 )
 
 catkin_package(
@@ -47,6 +56,8 @@ catkin_package(
                    tf2_sensor_msgs
                    sensor_msgs
                    message_runtime
+                   std_srvs
+                   nav_msgs
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
 )

--- a/okvis_ros/include/okvis/Publisher.hpp
+++ b/okvis_ros/include/okvis/Publisher.hpp
@@ -141,6 +141,12 @@ namespace okvis
       parameters_ = parameters;
     }
 
+    /// \brief Set just T_Wc_W
+    /// @param parameters The parameters.
+    void setT_Wc_W(const okvis::kinematics::Transformation& T_Wc_W){
+      parameters_.publishing.T_Wc_W = T_Wc_W;
+    }
+
     /**
    * @brief Set the points that are published next.
    * @param pointsMatched Vector of 3D points that have been matched with existing landmarks.

--- a/okvis_ros/include/okvis/Subscriber.hpp
+++ b/okvis_ros/include/okvis/Subscriber.hpp
@@ -123,6 +123,10 @@ class Subscriber
   /// @brief Set the node handle. This sets up the callbacks. This is called in the constructor.
   void setNodeHandle(ros::NodeHandle& nh);
 
+  /// @brief Set custom world transformation for reloc callback @Hunter
+  void setT_Wc_W(okvis::kinematics::Transformation T_Wc_W);
+
+
  protected:
   /// @name ROS callbacks
   /// @{

--- a/okvis_ros/okvis/okvis_common/include/okvis/Parameters.hpp
+++ b/okvis_ros/okvis/okvis_common/include/okvis/Parameters.hpp
@@ -317,6 +317,11 @@ struct PublishingParameters {
   FrameName velocitiesFrame = FrameName::B; ///< B or S,  the frames in which the velocities of the selected trackedBodyFrame will be expressed in
 };
 
+// Hunter
+struct ResetPoseParameters {
+  bool isResetable;
+};
+
 /// @brief Struct to combine all parameters and settings.
 struct VioParameters {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -340,6 +345,7 @@ struct VioParameters {
   ClaheParams claheParams;  ///< Sharmin: CLAHE Parameters
   MiscParams miscParams;  ///< Sharmin: contains misc parameters, e.g. opencv image resize factor
   SonarParameters sonar;  ///< Sharmin: sonar parameters (T_SSo)
+  ResetPoseParameters resetableParams;  ///< Hunter: Reset pose parameters
 };
 
 } // namespace okvis

--- a/okvis_ros/okvis/okvis_common/src/VioParametersReader.cpp
+++ b/okvis_ros/okvis/okvis_common/src/VioParametersReader.cpp
@@ -365,6 +365,10 @@ void VioParametersReader::readConfigFile(const std::string& filename) {
 
   // *****  End Sharmin: Additional config ******//
 
+  // Hunter: Resetable pose parameters
+  success = parseBoolean(file["isResetable"], vioParameters_.resetableParams.isResetable);
+  if (!success) vioParameters_.resetableParams.isResetable = false;  // Default to false for backwards compatibility
+
   // camera calibration
   std::vector<CameraCalibration,Eigen::aligned_allocator<CameraCalibration>> calibrations;
   if(!getCameraCalibration(calibrations, file))

--- a/okvis_ros/package.xml
+++ b/okvis_ros/package.xml
@@ -33,5 +33,7 @@
   <depend>tf2_sensor_msgs</depend>
   <depend>message_generation</depend>
   <depend>message_runtime</depend>
-
+  <!-- Added by Hunter -->
+  <depend>std_srvs</depend>
+  <depend>nav_msgs</depend>
 </package>

--- a/okvis_ros/srv/OdometryTrigger.srv
+++ b/okvis_ros/srv/OdometryTrigger.srv
@@ -1,0 +1,5 @@
+nav_msgs/Odometry pose
+---
+# Return borrowed from std_srvs/Trigger
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
Hard reset calls the destructor to `ThreadedKFVio` and reinitializes it, optionally with a starting pose. Services `~reset` and `~reset_zero` perform this action. Using a soft reset is often preferable to a hard reset because SVIn2 can behave erratically during initialization.

Soft reset changes the custom world transformation `T_Wc_W` so subsequent poses are moved accordingly. The `~smooth_reset` service performs this action.

To enable this feature, the config file should include a flag `isResetable: true` (false by default for backwards compatibility).